### PR TITLE
Allow Pie chart title

### DIFF
--- a/python/adminui/chart.py
+++ b/python/adminui/chart.py
@@ -51,12 +51,13 @@ class PieChart(Element):
     Args:
         data: the data shown on the chart. 
             e.g. an array like [2, 3, 4, 5]
-        lables: labels corresponding to the data. Must be to the same length of the data
+        labels: labels corresponding to the data. Must be to the same length of the data
             e.g. ['a', 'b', 'c', 'd']
         height: the height of the chart
+        title: the title of the chart
     """
-    def __init__(self, data=[], labels=None, height=300, color=None, id=None):
-        super().__init__('PieChart', data=data, labels=labels, style={'height': height, 'color': color}, id=id)
+    def __init__(self, data=[], labels=None, height=300, color=None, title=None, id=None):
+        super().__init__('PieChart', data=data, labels=labels, style={'height': height, 'color': color, 'title': title}, id=id)
 
 class ScatterPlot(Element):
     """Create a bar chart

--- a/src/pages/pageParts/components/Charts/pieChart.tsx
+++ b/src/pages/pageParts/components/Charts/pieChart.tsx
@@ -12,9 +12,21 @@ export interface PieChartProps {
     height?: number;
 }
 
+const styles ={
+    mainTitle:{
+      fontSize:20,
+      color:"black",
+      margin: "auto",
+      "padding-left": 52,
+      "padding-bottom": 20,
+      "box-sizing": "border-box"
+    }
+}    
+    
 export interface PieChartStyle {
     height: number;
     columns?: string[];
+    title: string;
   }
   
 
@@ -34,6 +46,11 @@ const PieChart: React.FC<PieChartProps> = props => {
           forceFit
           height={chartStyle.height}
         >
+        <h3 className='main-title' style={styles.mainTitle}>
+          <center>
+            {chartStyle.title}
+          </center>
+        </h3>
           <Coord type="theta"/>
           <Tooltip showTitle={false} />
           <Geom


### PR DESCRIPTION
This change would allow users to set titles to PieCharts

Example Output:

![example_chart](https://user-images.githubusercontent.com/62536344/172812568-7e5af357-aa19-4c87-ac6a-e01b107fd6b1.PNG)


